### PR TITLE
Hotfix for calling layer properties service for datasets in Map Metadata

### DIFF
--- a/src/modules/documentExecution/dashboard/widget/WidgetEditor/MapWidget/metadata/MapWidgetMetadata.vue
+++ b/src/modules/documentExecution/dashboard/widget/WidgetEditor/MapWidget/metadata/MapWidgetMetadata.vue
@@ -65,7 +65,7 @@ export default defineComponent({
             }
         },
         async loadAvailableProperties() {
-            if (!this.layer) return
+            if (!this.layer || this.layer.type === 'dataset') return
 
             if (this.propertiesCache.has(this.layer.layerId)) {
                 this.layer.properties = this.propertiesCache.get(this.layer.layerId)


### PR DESCRIPTION
- Hotfix for calling layer properties service for datasets in Map Metadata